### PR TITLE
projects(path): updated folder path from ~/Projects to ~/BoxenProject…

### DIFF
--- a/modules/projects/manifests/coder.pp
+++ b/modules/projects/manifests/coder.pp
@@ -1,6 +1,6 @@
 class projects::coder {
 
-  $projects = "/Users/${::boxen_user}/Projects"
+  $projects = "/Users/${::boxen_user}/BoxenProjects"
   $coder    = "${projects}/coder"
 
   file { $projects: ensure => directory }

--- a/modules/projects/manifests/explorer.pp
+++ b/modules/projects/manifests/explorer.pp
@@ -1,6 +1,6 @@
 class projects::explorer {
 
-  $projects = "/Users/${::boxen_user}/Projects"
+  $projects = "/Users/${::boxen_user}/BoxenProjects"
   $explorer = "${projects}/explorer"
 
   file { $projects: ensure => directory }

--- a/modules/projects/manifests/uikit.pp
+++ b/modules/projects/manifests/uikit.pp
@@ -1,6 +1,6 @@
 class projects::uikit {
 
-  $projects = "/Users/${::boxen_user}/Projects"
+  $projects = "/Users/${::boxen_user}/BoxenProjects"
   $uikit    = "${projects}/uikit"
 
   file { $projects: ensure => directory }


### PR DESCRIPTION
Suggesting Projects Path Update

Some users are already using Projects as their base folder for their projects, this pull request suggests that it must be differentiated with user created folder vs boxen created folder for projects thus suggests that it should be moved to ~/BoxenProjects for boxen <project_name> installations