### PR TITLE
sh to add self-signed certs for mjolnir

### DIFF
--- a/modules/projects/manifests/coder.pp
+++ b/modules/projects/manifests/coder.pp
@@ -8,14 +8,14 @@ class projects::coder {
 
   file { 'self_signed_certs':
     ensure => file,
-    source => 'puppet:///modules/projects/templates/shell/certs.sh',
+    source => '/opt/boxen/repo/modules/projects/templates/shell/certs.sh',
     path   => "${projects}/certs.sh",
     owner  => 'root',
     notify => Exec['CreateSelfSignedCerts'],
   }
 
   exec { 'CreateSelfSignedCerts':
-    command     => '${projects}/certs.sh',
+    command     => "sh ${projects}/certs.sh",
     refreshonly => true
   }
 


### PR DESCRIPTION
Automates the creation of self-signed certs for mjolnir projects, however it is still required to manually add these certs to keychain (under `System` and not `login`). This update lets authenticate with oauth providers that requires `https` e.g. dropbox